### PR TITLE
Setting for updating planner items in the past

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import typescript from '@rollup/plugin-typescript';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import copy from 'rollup-plugin-copy';
-const TEST_VAULT = 'test-vault/.obsidian/plugins/day-planner';
+const TEST_VAULT = 'test-vault/.obsidian/plugins/obsidian-day-planner';
 
 export default {
   input: 'src/main.ts',

--- a/src/planner-md.ts
+++ b/src/planner-md.ts
@@ -80,7 +80,7 @@ export default class PlannerMarkdown {
         }
     }
 
-    getPlannerSegment(fileContents: string[]): {startLine: number, endLine: number, dayPlannerContents: string[]} {
+    private getPlannerSegment(fileContents: string[]): {startLine: number, endLine: number, dayPlannerContents: string[]} {
         let startLine = -1;
         let endLine = 0;
         for (let i = 0; i < fileContents.length; i++) {
@@ -97,11 +97,20 @@ export default class PlannerMarkdown {
         return {startLine, endLine, dayPlannerContents}
     }
 
-    updateItemCompletion(item: PlanItem, complete: boolean) {
-        return `- [${complete ? 'x' : ' '}] ${item.rawTime} ${item.displayText()}`;
+    private updateItemCompletion(item: PlanItem, complete: boolean) {
+        let check = this.check(complete);
+        //Override to use current (user inputted) state if plugin setting is enabled
+        if(!this.settings.completePastItems) {
+            check = this.check(item.isCompleted);
+        }
+        return `- [${check}] ${item.rawTime} ${item.displayText()}`;
+    }
+
+    private check(check: boolean) {
+        return check ? 'x' : ' ';
     }
     
-    currentItemText(planSummary:PlanSummaryData): string{
+    private currentItemText(planSummary:PlanSummaryData): string{
         try {
             const current = planSummary.current;
             const next = planSummary.next;

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -34,11 +34,22 @@ import DayPlanner from './main';
             }));
 
       new Setting(containerEl)
+        .setName('Complete past planner items')
+        .setDesc('Mark checkboxes for tasks and breaks in the past as completed')
+        .addToggle(toggle => 
+          toggle
+            .setValue(this.plugin.settings.completePastItems)
+            .onChange((value:boolean) => {
+              this.plugin.settings.completePastItems = value;
+              this.plugin.saveData(this.plugin.settings);
+            }));
+
+      new Setting(containerEl)
         .setName('Mermaid Gantt')
         .setDesc('Include a mermaid gantt chart generated for the day planner')
         .addToggle(toggle => 
           toggle
-            .setValue(this.plugin.settings.mermaid || false)
+            .setValue(this.plugin.settings.mermaid)
             .onChange((value:boolean) => {
               this.plugin.settings.mermaid = value;
               this.plugin.saveData(this.plugin.settings);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ export class DayPlannerSettings {
   mode: DayPlannerMode = DayPlannerMode.File;
   mermaid: boolean = false;
   notesToDates: NoteForDate[] = [];
+  completePastItems: boolean = true;
 }
 
 export class NoteForDate {


### PR DESCRIPTION
A setting that allows the user to update the checkboxes for planner items in the past. Closes #1.

This will be included in the next release (0.2.0).