### PR TITLE
Mark END plan item as isPast when it is current item.

### DIFF
--- a/src/plan-data.ts
+++ b/src/plan-data.ts
@@ -26,6 +26,10 @@ export class PlanSummaryData {
                 const next = this.items[i+1];
                 if(item.time < now && (item.isEnd || (next && now < next.time))) {
                     this.current = item;
+                    if (item.isEnd) {
+                        item.isPast = true;
+                        this.past.push(item);
+                    }
                     this.next = item.isEnd ? null : next;
                 } else if(item.time < now) {
                     item.isPast = true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
 
   "compilerOptions": {
     "baseUrl": ".",
-    "inlineSourceMap": true,
     "inlineSources": true,
     // "module": "ESNext",
     // "target": "es6",


### PR DESCRIPTION
Fixes #66.

In the usual case a current plan item won't get marked as isPast until the next item turns current, however, the endItem should be marked as done right away when we arrive at that PlanItem.