### PR TITLE
Adding information to command mode section on how to start using it

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ The plugin automatically generates day planner notes for each day within a Day P
 
 Commands are used to insert a Day Planner for today within any note as well as unlinking the Day Planner for today from its current note.
 
+>Note: To add the Day Planner to the current note you first need to Link the Day Planner to the current note by running either one of the commands "Day Planner: Link today's Day Planner to the current Note" or "Day Planner: Add a Day Planner template for today to the current note" from the command palette.
+
 The Day Planner can be placed anywhere within a note as long as the format provided is used. Only the Day Planner section of the note will be updated as time progresses.
 
 ### Complete Past Planner Items


### PR DESCRIPTION
The plugin starts up in file mode however when you shift to command mode in the settings and try to insert a day planner header in a note it does not work instantly. It was unclear in the documentation that we need to first link the Day planner to the current note by "unlinking" it from the Day planner file or just by running the two commands mention in the git message. Hence adding this information as a note to Readme. 